### PR TITLE
feat: support custom fallback group for wildcards in group_imports

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -2307,6 +2307,7 @@ For a given config:
 ```toml
 group_imports = [
     ["$std::*", "proc_macro::*"],
+    ["*"],
     ["my_crate::*", "crate::*::xyz"],
     ["$crate::*"],
 ]
@@ -2317,6 +2318,8 @@ The following order would be set:
 ```rust
 use proc_macro::Span;
 use std::rc::Rc;
+
+use rand;
 
 use crate::abc::xyz;
 use my_crate::a::B;
@@ -2375,7 +2378,7 @@ specific version of rustfmt is used in your CI, use this option.
 
 The width threshold for an array element to be considered "short".
 
-The layout of an array is dependent on the length of each of its elements. 
+The layout of an array is dependent on the length of each of its elements.
 If the length of every element in an array is below this threshold (all elements are "short") then the array can be formatted in the mixed/compressed style, but if any one element has a length that exceeds this threshold then the array elements will have to be formatted vertically.
 
 - **Default value**: `10`

--- a/src/reorder.rs
+++ b/src/reorder.rs
@@ -11,7 +11,7 @@ use std::cmp::{Ord, Ordering};
 use rustc_ast::ast;
 use rustc_span::{symbol::sym, Span};
 
-use crate::config::{Config, GroupImportsTactic, WildcardGroups};
+use crate::config::{Config, GroupImportsTactic, WildcardGroup, WildcardGroups};
 use crate::imports::{normalize_use_trees_with_granularity, UseSegmentKind, UseTree};
 use crate::items::{is_mod_decl, rewrite_extern_crate, rewrite_mod};
 use crate::lists::{itemize_list, write_list, ListFormatting, ListItem};
@@ -173,7 +173,10 @@ fn contains_macro_use_attr(item: &ast::Item) -> bool {
 
 fn group_imports_custom(wildcards: WildcardGroups, uts: Vec<UseTree>) -> Vec<Vec<UseTree>> {
     let mut groups = vec![vec![]; wildcards.len() + 1];
-    let fallback_group = groups.len() - 1;
+    let fallback_group = wildcards
+        .iter()
+        .position(WildcardGroup::is_fallback)
+        .unwrap_or(groups.len() - 1);
 
     for ut in uts.into_iter() {
         let ut_path_str = ut.to_string();

--- a/tests/config/wildcard-example.toml
+++ b/tests/config/wildcard-example.toml
@@ -1,5 +1,6 @@
 group_imports = [
     ["$std::*", "proc_macro::*"],
+    ["*"],
     ["my_crate::*", "crate::*::xyz"],
     ["$crate::*"],
 ]

--- a/tests/config/wildcard-fallback.toml
+++ b/tests/config/wildcard-fallback.toml
@@ -1,0 +1,8 @@
+group_imports = [
+    ["a", "b::c"],
+    ["$crate::x::*"],
+    ["$std::sync"],
+    ["*"],
+    ["*::ipsum::*"],
+    ["xyz::abc::dez"],
+]

--- a/tests/source/wildcard-group-import/config-example.rs
+++ b/tests/source/wildcard-group-import/config-example.rs
@@ -1,4 +1,4 @@
-// rustfmt-config: wildcard-example.rs
+// rustfmt-config: wildcard-example.toml
 use self::X;
 use super::Y;
 use crate::abc::xyz;
@@ -6,4 +6,5 @@ use crate::Z;
 use my_crate::a::B;
 use my_crate::A;
 use proc_macro::Span;
+use rand;
 use std::rc::Rc;

--- a/tests/source/wildcard-group-import/fallback.rs
+++ b/tests/source/wildcard-group-import/fallback.rs
@@ -1,0 +1,13 @@
+// rustfmt-config: wildcard-fallback.toml
+use self::x;
+use crate::x::y;
+use crate::y;
+use a;
+use a::ipsum::b;
+use b::c;
+use b::c::d;
+use c::d::ipsum::b;
+use core::sync;
+use core::sync::A;
+use std::sync;
+use xyz::abc::dez;

--- a/tests/target/wildcard-group-import/config-example.rs
+++ b/tests/target/wildcard-group-import/config-example.rs
@@ -1,6 +1,8 @@
-// rustfmt-config: wildcard-example.rs
+// rustfmt-config: wildcard-example.toml
 use proc_macro::Span;
 use std::rc::Rc;
+
+use rand;
 
 use crate::abc::xyz;
 use my_crate::a::B;

--- a/tests/target/wildcard-group-import/fallback.rs
+++ b/tests/target/wildcard-group-import/fallback.rs
@@ -1,0 +1,18 @@
+// rustfmt-config: wildcard-fallback.toml
+use a;
+use b::c;
+
+use crate::x::y;
+
+use core::sync;
+use std::sync;
+
+use self::x;
+use crate::y;
+use b::c::d;
+use core::sync::A;
+
+use a::ipsum::b;
+use c::d::ipsum::b;
+
+use xyz::abc::dez;


### PR DESCRIPTION
To support custom fallback positions, we store the config `["*"]` as a `Fallback` variant of the (now) enum `WildcardGroup`.
In the `matches` fn, if we have a `Fallback` variant, we always return false.
After that, in `group_imports_custom`, we get the position of enum in the `WildcardGroups` vec which is of the variant `Fallback` or use `groups.len() - 1` as default (unchanged).